### PR TITLE
Fix tests build on Windows and Linux

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -19,4 +19,9 @@ cc_test(
         "//:eventuals",
         "@gtest//:gtest_main",
     ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [], # Windows
+        "@bazel_tools//src/conditions:darwin": [], # macOS
+        "//conditions:default": ["-ldl"], # Linux
+    }),
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -20,7 +20,7 @@ cc_test(
         "@gtest//:gtest_main",
     ],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [], # Windows
+        "@bazel_tools//src/conditions:windows": [ "/DYNAMICBASE WS2_32.Lib Advapi32.lib Iphlpapi.lib Userenv.lib User32.lib" ], # Windows
         "@bazel_tools//src/conditions:darwin": [], # macOS
         "//conditions:default": ["-ldl"], # Linux
     }),


### PR DESCRIPTION
We have to link to libdl for tests to build correctly. It doesn't affect Windows and MacOS builds.