### PR TITLE
Fix Linux and Windows builds

### DIFF
--- a/stout/callback.h
+++ b/stout/callback.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <type_traits> // For std::aligned_storage.
+#include <utility>
 
 ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fix for "std doesn't have a function called move" error in callback.h.