### PR TITLE
Use bash instead of shell for tools/bootstrap

### DIFF
--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Check for existence of git.
 which git >/dev/null


### PR DESCRIPTION
On some platforms shell is symlinked to dash and it doesn't support double
brackets. Bash should be enough for bootstrap to work fine on most systems.