### PR TITLE
Add Filter wrapper Interface

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
         "stout/dns-resolver.h",
         "stout/signal.h",
         "stout/collect.h",
+        "stout/filter.h",
     ],
     srcs = [
         "stout/scheduler.cc",

--- a/stout/filter.h
+++ b/stout/filter.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "stout/eventual.h"
+#include "stout/stream.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+////////////////////////////////////////////////////////////////////////
+
+struct _Filter {
+  template <typename K_, typename F_, typename Arg_>
+  struct Continuation {
+    void Start(TypeErasedStream& stream) {
+      stream_ = &stream;
+      k_.Start(stream);
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      k_.Fail(std::forward<Args>(args)...);
+    }
+
+    void Stop() {
+      k_.Stop();
+    }
+
+    template <typename... Args>
+    void Body(Args&&... args) {
+      if (f_(std::forward<Args>(args)...)) {
+        k_.Body(std::forward<Args>(args)...);
+      } else {
+        stream_->Next();
+      }
+    }
+
+    void Ended() {
+      k_.Ended();
+    }
+
+    K_ k_;
+    F_ f_;
+
+    TypeErasedStream* stream_ = nullptr;
+  };
+
+  // Using at compose.h to correctly create custom Continuation structure
+  // with provided lambda function to filter
+  template <typename F_>
+  struct Composable {
+    template <typename Arg>
+    using ValueFrom = Arg;
+
+    template <typename Arg, typename K>
+    auto k(K k) && {
+      return Continuation<K, F_, Arg>{std::move(k), std::move(f_)};
+    }
+
+    F_ f_;
+  };
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace detail
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename F>
+auto Filter(F f) {
+  return detail::_Filter::Composable<F>{std::move(f)};
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -21,6 +21,7 @@ cc_test(
         "dns-resolver.cc",
         "signal.cc",
         "collect.cc",
+        "filter.cc",
     ],
     deps = [
         "//:eventuals",

--- a/test/filter.cc
+++ b/test/filter.cc
@@ -1,0 +1,100 @@
+#include "stout/filter.h"
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "stout/collect.h"
+#include "stout/iterate.h"
+#include "stout/loop.h"
+#include "stout/map.h"
+#include "stout/terminal.h"
+#include "stout/then.h"
+
+using stout::eventuals::Collect;
+using stout::eventuals::Filter;
+using stout::eventuals::Iterate;
+using stout::eventuals::Loop;
+using stout::eventuals::Map;
+using stout::eventuals::Then;
+
+TEST(Filter, OddLoopFlow) {
+  std::vector<int> v = {5, 12, 17};
+  auto begin = v.begin();
+  auto end = v.end();
+
+  auto s = [&]() {
+    return Iterate(begin, end)
+        | Filter([](int x) {
+             return x % 2 == 1;
+           })
+        | Loop<int>()
+              .context(0)
+              .body([](auto& sum, auto& stream, auto&& value) {
+                sum += value;
+                stream.Next();
+              })
+              .ended([](auto& sum, auto& k) {
+                k.Start(sum);
+              });
+  };
+
+  EXPECT_EQ(22, *s());
+}
+
+TEST(Filter, OddCollectFlow) {
+  std::vector<int> v = {5, 12, 17};
+  auto begin = v.begin();
+  auto end = v.end();
+
+  auto s = [&]() {
+    return Iterate(begin, end)
+        | Filter([](int x) { return x % 2 == 1; })
+        | Collect<std::set<int>>();
+  };
+
+  auto res = *s();
+
+  ASSERT_EQ(res.size(), 2);
+  EXPECT_EQ(*res.begin(), 5);
+  EXPECT_EQ(*(++res.begin()), 17);
+}
+
+TEST(Filter, OddMapLoopFlow) {
+  std::vector<int> v = {5, 12, 17};
+
+  auto s = [&]() {
+    return Iterate(v)
+        | Filter([](int x) { return x % 2 == 1; })
+        | Map(Then([](int x) { return x + 1; }))
+        | Loop<int>()
+              .context(0)
+              .body([](auto& sum, auto& stream, auto&& value) {
+                sum += value;
+                stream.Next();
+              })
+              .ended([](auto& sum, auto& k) {
+                k.Start(sum);
+              });
+  };
+
+  EXPECT_EQ(24, *s());
+}
+
+TEST(Filter, OddMapCollectFlow) {
+  std::vector<int> v = {5, 12, 17};
+
+  auto s = [&]() {
+    return Iterate(v)
+        | Filter([](int x) { return x % 2 == 1; })
+        | Map(Then([](int x) { return x + 1; }))
+        | Collect<std::unordered_set<int>>();
+  };
+
+  auto res = *s();
+
+  ASSERT_EQ(res.size(), 2);
+  EXPECT_EQ(*res.begin(), 18);
+  EXPECT_EQ(*++res.begin(), 6);
+}


### PR DESCRIPTION
New Filter eventual, that takes some lambda function F that split values from the previous stream.
Example of usage:

`Iterate(v)
    |    Filter([](int x){ return x % 2 == 0; })
    |    Collect<std::vector<int>>()
...`

All odd numbers will appear at vector after Collect