### PR TITLE
Fix compilation warnings while using Iterate with std::array

### DIFF
--- a/stout/iterate.h
+++ b/stout/iterate.h
@@ -73,7 +73,7 @@ auto Iterate(Container&& container) {
 template <typename T, size_t n>
 auto Iterate(std::array<T, n>&& container) {
   return Stream<T>()
-      .next([container = std::move(container), i = 0](auto& k) mutable {
+      .next([container = std::move(container), i = 0u](auto& k) mutable {
         if (i != container.size()) {
           k.Emit(container[i++]);
         } else {


### PR DESCRIPTION
While using Iterate with std::array there 'i' variable at lambda and i is int now, so there are a lot of warnings about comparison std::array.size -> size_t and i -> int