### PR TITLE
Fix Signal implementation and re-enable tests

### DIFF
--- a/stout/event-loop.cc
+++ b/stout/event-loop.cc
@@ -139,7 +139,7 @@ EventLoop::~EventLoop() {
     uv_print_all_handles(&loop_, stderr);
   }
 
-  uv_loop_close(&loop_);
+  CHECK_EQ(uv_loop_close(&loop_), 0);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -19,7 +19,7 @@ cc_test(
         "event-loop-test.h",
         "iterate.cc",
         "dns-resolver.cc",
-        # "signal.cc",
+        "signal.cc",
         "collect.cc",
         "filter.cc",
         "take.cc",


### PR DESCRIPTION
1. This PR adds a RAII implementation for signals inside the EventLoop to ensure the correct behavior.
Due to the design choices in libuv the handle is now allocated on heap and there's an added EventLoop::CloseCallback method which is called on the next iteration of uv_run to ensure de-allocation.

2. Added a check in EventLoop::~EventLoop to ensure that uv_close function returns 0 and not UV_EBUSY value or any other incorrect value.