### PR TITLE
Added check_format_code.yml

### DIFF
--- a/.github/workflows/check_format_code.yml
+++ b/.github/workflows/check_format_code.yml
@@ -1,0 +1,16 @@
+name: C/C++ Style Check
+
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run bootstrap
+      run: cd tools/ && ./bootstrap
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.0.0
+      with:
+        clang-format-version: '12'
+        check-path: '.'

--- a/test/parallel.cc
+++ b/test/parallel.cc
@@ -32,11 +32,11 @@ TEST(ParallelTest, Succeed) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Then([](int i) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-              return i + 1;
-            });
-          })
+             return Then([](int i) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(100));
+               return i + 1;
+             });
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {
@@ -68,11 +68,11 @@ TEST(ParallelTest, Done) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Then([](int i) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-              return i + 1;
-            });
-          })
+             return Then([](int i) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(100));
+               return i + 1;
+             });
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {
@@ -100,11 +100,11 @@ TEST(ParallelTest, IngressFail) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Then([](int i) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-              return i + 1;
-            });
-          })
+             return Then([](int i) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(100));
+               return i + 1;
+             });
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {
@@ -130,11 +130,11 @@ TEST(ParallelTest, IngressStop) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Then([](int i) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-              return i + 1;
-            });
-          })
+             return Then([](int i) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(100));
+               return i + 1;
+             });
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {
@@ -160,8 +160,8 @@ TEST(ParallelTest, WorkerFail) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Raise("error");
-          })
+             return Raise("error");
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {
@@ -187,11 +187,11 @@ TEST(ParallelTest, WorkerStop) {
                  k.Ended();
                })
         | Parallel([]() {
-            return Eventual<int>()
-                .start([](auto& k, auto&&...) {
-                  k.Stop();
-                });
-          })
+             return Eventual<int>()
+                 .start([](auto& k, auto&&...) {
+                   k.Stop();
+                 });
+           })
         | Reduce(
                std::set<int>{2, 3, 4, 5, 6},
                [](auto& values) {


### PR DESCRIPTION
This .yml file helps to verify that a repo's formatting matches our
specifications (.clang-format file in the root directory), but doesn't
automatically fix any issues.

For now I need to figure out how to make this action automatically
check if every line of the code exceeds 80 characters and make it work
with BUILD.bazel and WORKSPACE.bazel files.