### PR TITLE
Refactor library into sub-libraries eventuals-events and eventuals-http and only build eventuals-http on macOS and Linux

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "eventuals",
+    name = "eventuals-base",
     hdrs = [
         "stout/undefined.h",
         "stout/sequence.h",
@@ -30,14 +30,9 @@ cc_library(
         "stout/closure.h",
         "stout/compose.h",
         "stout/catch.h",
-        "stout/event-loop.h",
-        "stout/timer.h",
         "stout/head.h",
-        "stout/filesystem.h",
         "stout/parallel.h",
         "stout/iterate.h",
-        "stout/dns-resolver.h",
-        "stout/signal.h",
         "stout/collect.h",
         "stout/filter.h",
         "stout/take.h",
@@ -45,12 +40,54 @@ cc_library(
     srcs = [
         "stout/scheduler.cc",
         "stout/static-thread-pool.cc",
-        "stout/event-loop.cc",
     ],
     deps = [
         "@com_github_google_glog//:glog",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "eventuals-events",
+    hdrs = [
+        "stout/event-loop.h",
+        "stout/timer.h",
+        "stout/filesystem.h",
+        "stout/dns-resolver.h",
+        "stout/signal.h",
+    ],
+    srcs = [
+        "stout/event-loop.cc",
+    ],
+    deps = [
+        ":eventuals-base",
         "@com_github_libuv_libuv//:libuv",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "eventuals-http",
+    deps = [
+        ":eventuals-base",
         "@com_github_curl_curl//:libcurl",
     ],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "eventuals",
+    deps = [
+        ":eventuals-base",
+        ":eventuals-events",
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            # NOTE: we don't link eventuals-http on Windows because we
+            # currently can't reliably compile either OpenSSL or
+            # boringssl on Windows (see #59).
+            "//:eventuals-http",
+        ],
+    }),
     visibility = ["//visibility:public"],
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,29 +1,44 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
+
+eventuals_base_sources = [
+    "eventual.cc",
+    "stream.cc",
+    "lock.cc",
+    "repeat.cc",
+    "then.cc",
+    "conditional.cc",
+    "callback.cc",
+    "static-thread-pool.cc",
+    "task.cc",
+    "closure.cc",
+    # "parallel.cc",
+    "iterate.cc",
+    "collect.cc",
+    "filter.cc",
+    "take.cc",
+]
+
+eventuals_events_sources = [
+    "timer.cc",
+    "filesystem.cc",
+    "event-loop-test.h",
+    "dns-resolver.cc",
+    "signal.cc",
+]
+
+eventuals_http_sources = select({
+    "@bazel_tools//src/conditions:windows": [],
+    "//conditions:default": [
+        # NOTE: we don't compile any of the tests for eventuals-http
+        # on Windows because we currently can't reliably compile
+        # either OpenSSL or boringssl on Windows (see #59).
+    ],
+})
+
 cc_test(
     name = "eventuals",
-    srcs = [
-        "eventual.cc",
-        "stream.cc",
-        "lock.cc",
-        "repeat.cc",
-        "then.cc",
-        "conditional.cc",
-        "callback.cc",
-        "static-thread-pool.cc",
-        "task.cc",
-        "closure.cc",
-        # "parallel.cc",
-        "timer.cc",
-        "filesystem.cc",
-        "event-loop-test.h",
-        "iterate.cc",
-        "dns-resolver.cc",
-        "signal.cc",
-        "collect.cc",
-        "filter.cc",
-        "take.cc",
-    ],
+    srcs = eventuals_base_sources + eventuals_events_sources + eventuals_http_sources,
     deps = [
         "//:eventuals",
         "@com_github_google_googletest//:gtest_main",


### PR DESCRIPTION
Addresses #60.