### PR TITLE
Add Range streaming Interface

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ cc_library(
         "stout/collect.h",
         "stout/filter.h",
         "stout/take.h",
+        "stout/range.h",
     ],
     srcs = [
         "stout/scheduler.cc",

--- a/stout/range.h
+++ b/stout/range.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "stout/stream.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+struct _Range {
+  template <typename K_, typename Arg_>
+  struct Continuation : public detail::TypeErasedStream {
+    // NOTE: explicit constructor because inheriting 'TypeErasedStream'.
+    Continuation(K_ k, int from, int to, int step)
+      : k_(std::move(k)),
+        from_(from),
+        to_(to),
+        step_(step) {}
+
+    void Start() {
+      k_.Start(*this);
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      k_.Fail(std::forward<Args>(args)...);
+    }
+
+    void Stop() {
+      k_.Stop();
+    }
+
+    void Ended() {
+      k_.Ended();
+    }
+
+    void Next() override {
+      if (from_ == to_
+          || step_ == 0
+          || (from_ > to_ && step_ > 0)
+          || (from_ < to_ && step_ < 0)) {
+        k_.Ended();
+      } else {
+        int temp = from_;
+        from_ += step_;
+        k_.Body(temp);
+      }
+    }
+
+    void Done() override {
+      k_.Ended();
+    }
+
+    K_ k_;
+    int from_;
+    const int to_;
+    const int step_;
+  };
+
+  struct Composable {
+    template <typename>
+    using ValueFrom = int;
+
+    template <typename Arg, typename K>
+    auto k(K k) && {
+      return Continuation<K, Arg>{std::move(k), from_, to_, step_};
+    }
+
+    const int from_;
+    const int to_;
+    const int step_;
+  };
+};
+
+inline auto Range(int from, int to, int step) {
+  return _Range::Composable{from, to, step};
+}
+
+inline auto Range(int from, int to) {
+  return Range(from, to, 1);
+}
+
+inline auto Range(int to) {
+  return Range(0, to, 1);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -17,6 +17,7 @@ eventuals_base_sources = [
     "collect.cc",
     "filter.cc",
     "take.cc",
+    "range.cc",
 ]
 
 eventuals_events_sources = [

--- a/test/range.cc
+++ b/test/range.cc
@@ -1,0 +1,89 @@
+#include "stout/range.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stout/collect.h"
+#include "stout/terminal.h"
+
+using stout::eventuals::Collect;
+using stout::eventuals::Range;
+using testing::ElementsAre;
+
+TEST(Range, CommonFlow) {
+  auto s = Range(0, 5)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(0, 1, 2, 3, 4));
+}
+
+TEST(Range, IncorrectSetup) {
+  auto s = Range(2, 0)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre());
+}
+
+TEST(Range, NegativeRange) {
+  auto s = Range(-2, 2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(-2, -1, 0, 1));
+}
+
+TEST(Range, NegativeFrom) {
+  auto s = Range(-2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre());
+}
+
+TEST(Range, DefaultFrom) {
+  auto s = Range(3)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(0, 1, 2));
+}
+
+TEST(Range, SpecifiedStep) {
+  auto s = Range(0, 10, 2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(0, 2, 4, 6, 8));
+}
+
+TEST(Range, SpecifiedNegativeStep) {
+  auto s = Range(10, 0, -2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(10, 8, 6, 4, 2));
+}
+
+TEST(Range, SpecifiedStepIncorrect) {
+  auto s = Range(10, 0, 2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre());
+}
+
+TEST(Range, SpecifiedStepIncorrectNegative) {
+  auto s = Range(0, -10, 2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre());
+}
+
+TEST(Range, SpecifiedIncorrect) {
+  auto s = Range(0, 10, -2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre());
+}
+
+TEST(Range, SpecifiedStepNegative) {
+  auto s = Range(0, -10, -2)
+      | Collect<std::vector<int>>();
+
+  EXPECT_THAT(*s, ElementsAre(0, -2, -4, -6, -8));
+}


### PR DESCRIPTION
`Range` interface gives the stream that iterates through the sequence of given ints.
Examples:
```
Range(10, 20)
| Map(Then([](int x){ return x + 5; }))
| Collect<std::vector<int>>
```
