### PR TITLE
Introduce 'Let'

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ cc_library(
         "stout/filter.h",
         "stout/take.h",
         "stout/range.h",
+        "stout/let.h",
     ],
     srcs = [
         "stout/scheduler.cc",

--- a/stout/event-loop.h
+++ b/stout/event-loop.h
@@ -352,14 +352,14 @@ class EventLoop : public Scheduler {
   }
 
  private:
-  void Prepare();
+  void Check();
 
   static void CloseCallback(uv_handle_t* handle) {
     delete handle;
   }
 
   uv_loop_t loop_;
-  uv_prepare_t prepare_;
+  uv_check_t check_;
   uv_async_t async_;
 
   std::atomic<bool> running_ = false;

--- a/stout/let.h
+++ b/stout/let.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "stout/closure.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+namespace eventuals {
+
+////////////////////////////////////////////////////////////////////////
+
+// 'Let()' provides syntactic sugar for using a 'Closure()' when you
+// effectively want to introduce a binding that will persist within
+// the enclosing scope.
+//
+// Think of it like a "let binding" that exists in numerous languages,
+// for example:
+//
+// let foo = SomethingThatReturnsAFoo();
+//
+// You can use 'Let()' anywhere that you would have been able to use a
+// callable where you could have returned a 'Closure()' from said
+// callable. For example, you can use 'Let()' with 'Then()':
+//
+// SomethingThatReturnsAFoo()
+//     | Then(Let([](auto& foo) {
+//         return DoSomethingAsynchronouslyWithFoo(foo)
+//             | Then([&]() {
+//                  return DoSomethingSynchronouslyWithFoo(foo);
+//                });
+//       }));
+//
+// In the above example we need to use 'foo' and rather than
+// explicitly doing a 'std::move()' and use a 'Closure()' ourselves we
+// can simplify the code by using a 'Let()'.
+template <typename F>
+auto Let(F f) {
+  return [f = std::move(f)](auto value) mutable {
+    // NOTE: we need to take 'value' above by value and 'std::move()'
+    // it below to capture it otherwise compilers find it hard to
+    // instantiate the nested lambda types (see
+    // https://stackoverflow.com/q/66617181).
+    return Closure([&, value = std::move(value)]() mutable {
+      return f(value);
+    });
+  };
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////

--- a/stout/timer.h
+++ b/stout/timer.h
@@ -5,7 +5,7 @@
 namespace stout {
 namespace eventuals {
 
-auto Timer(const std::chrono::milliseconds& milliseconds) {
+inline auto Timer(const std::chrono::milliseconds& milliseconds) {
   return Clock().Timer(milliseconds);
 }
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -18,6 +18,7 @@ eventuals_base_sources = [
     "filter.cc",
     "take.cc",
     "range.cc",
+    "let.cc",
 ]
 
 eventuals_events_sources = [

--- a/test/let.cc
+++ b/test/let.cc
@@ -1,0 +1,44 @@
+#include "stout/let.h"
+
+#include "gtest/gtest.h"
+#include "stout/event-loop.h"
+#include "stout/just.h"
+#include "stout/terminal.h"
+#include "stout/then.h"
+#include "stout/timer.h"
+#include "test/event-loop-test.h"
+
+using stout::eventuals::EventLoop;
+using stout::eventuals::Just;
+using stout::eventuals::Let;
+using stout::eventuals::Then;
+using stout::eventuals::Timer;
+
+class LetTest : public EventLoopTest {};
+
+TEST_F(LetTest, Let) {
+  struct Foo {
+    int i;
+  };
+
+  auto e = []() {
+    return Just(Foo{41})
+        | Then(Let([](auto& foo) {
+             return Then([&]() {
+                      foo.i += 1;
+                    })
+                 | Timer(std::chrono::milliseconds(1))
+                 | Then([&]() {
+                      return foo.i;
+                    });
+           }));
+  };
+
+  auto [future, k] = Terminate(e());
+
+  k.Start();
+
+  EventLoop::Default().Run();
+
+  EXPECT_EQ(42, future.get());
+}


### PR DESCRIPTION
'Let()' provides syntactic sugar for using a 'Closure()' when you
effectively want to introduce a binding that will persist within the
enclosing scope.