### PR TITLE
Remove `Install LLVM and Clang` task on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,23 +16,18 @@ jobs:
       # Checkout the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v1
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "12.0"
-
       - name: Check for bazel
         run: bazel --version
 
       - name: Build
-        run: bazel build --spawn_strategy=local --copt="-g" --strip="never" :eventuals
+        run: bazel build --spawn_strategy=local --strip="never" :eventuals
 
       - name: Debug Build using tmate (if failure)
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
       - name: Test
-        run: bazel test --spawn_strategy=local --copt="-g" --strip="never" --test_output=errors test:eventuals --test_arg=--gtest_shuffle --test_arg=--gtest_repeat=100
+        run: bazel test --spawn_strategy=local --strip="never" --test_output=errors test:eventuals --test_arg=--gtest_shuffle --test_arg=--gtest_repeat=100
 
       - name: Debug Test using tmate (if failure)
         if: ${{ failure() }}


### PR DESCRIPTION
We do not need to run this task cause there was an update. Use the link below
to see it:
https://github.com/actions/virtual-environments/commit/a908240ead0632d98143582e0cdea014ee28629f (images/win/Windows2019-Readme.md Line 18)