### PR TITLE
Fix bug in test where thread might use deallocated memory

### DIFF
--- a/test/timer.cc
+++ b/test/timer.cc
@@ -114,11 +114,11 @@ TEST_F(EventLoopTest, InterruptTimer) {
     interrupt.Trigger();
   });
 
-  thread.detach();
-
   EventLoop::Default().Run();
 
   EXPECT_THROW(future.get(), eventuals::StoppedException);
+
+  thread.join();
 }
 
 


### PR DESCRIPTION
Test crashes that we've seen as recorded in #57 and [here](https://github.com/3rdparty/stout-eventuals/pull/72/checks?check_run_id=3764191052) and [here](https://github.com/3rdparty/stout-eventuals/pull/72/checks?check_run_id=3764191055) can be traced back to `EventLoopTest.InterruptTimer` being the previous test that ran. After investigating we noticed that `EventLoopTest.InterruptTimer` has a thread that has references to memory on the stack that might go out of scope because the thread was detached. This PR resolves #57 by ensuring that the thread has completed before the stack gets destructed and deallocated.