### PR TITLE
Lower time duration of DNS Fail test on Windows

### DIFF
--- a/test/dns-resolver.cc
+++ b/test/dns-resolver.cc
@@ -38,7 +38,7 @@ TEST_F(DomainNameResolveTest, Succeed) {
 
 
 TEST_F(DomainNameResolveTest, Fail) {
-  std::string address = "localhost1", port = "6667";
+  std::string address = ";;!(*#!()%$%*(#*!~_+", port = "6667";
 
   auto e = DomainNameResolve(address, port);
 


### PR DESCRIPTION
DNS Fail test with 'localhost1' set as an address runs for 2-6 seconds depending on the machine. This commit fixes the issue with that particular test.