### PR TITLE
Clear default event loop before running tests

### DIFF
--- a/stout/event-loop.h
+++ b/stout/event-loop.h
@@ -294,13 +294,17 @@ class EventLoop : public Scheduler {
 
   // Getter/Resetter for default event loop.
   static EventLoop& Default();
-  static void DefaultReset();
+  static void ConstructDefault();
+  static void DestructDefault();
+
+  static void ConstructDefaultAndRunForeverDetached();
 
   EventLoop();
   EventLoop(const EventLoop&) = delete;
   virtual ~EventLoop();
 
   void Run();
+  void RunForever();
 
   template <typename T>
   void RunUntil(std::future<T>& future) {

--- a/test/event-loop-test.h
+++ b/test/event-loop-test.h
@@ -6,14 +6,10 @@
 class EventLoopTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    stout::eventuals::EventLoop::DefaultReset();
+    stout::eventuals::EventLoop::ConstructDefault();
   }
 
   void TearDown() override {
-    // TODO(benh): shutdown event loop so that we can ensure there
-    // aren't any active threads for making sure we don't have a
-    // thread/resource leak (consider using
-    // 'testing::internal::GetThreadCount()' to get the number of
-    // threads).
+    stout::eventuals::EventLoop::DestructDefault();
   }
 };


### PR DESCRIPTION
Currently you can "accidently" write a test which uses the default
event loop without properly extending from
'EventLoopTest'. Unfortunatly this means that if a previous test
didn't properly destruct the event loop (e.g., because it failed or
the test has a bug) then you may run into undefined state. In order to
make sure that everyone has a well-defined event loop they must extend
from 'EventLoopTest' and by ensuring that there is no default event
loop to start then a test that doesn't extend from 'EventLoopTest' (or
reset the default event loop on their own) will crash.