### PR TITLE
Add 'StreamForEach' interface

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,7 @@ cc_library(
         "stout/type-traits.h",
         "stout/undefined.h",
         "stout/until.h",
+        "stout/stream-for-each.h",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/stout/range.h
+++ b/stout/range.h
@@ -32,6 +32,10 @@ struct _Range {
       k_.Stop();
     }
 
+    void Register(Interrupt& interrupt) {
+      k_.Register(interrupt);
+    }
+
     void Ended() {
       k_.Ended();
     }

--- a/stout/stream-for-each.h
+++ b/stout/stream-for-each.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <optional>
+
+#include "stout/stream.h"
+#include "stout/terminal.h"
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+namespace eventuals {
+namespace detail {
+
+////////////////////////////////////////////////////////////////////////
+
+struct _StreamForEach {
+  template <typename StreamForEach_>
+  struct Adaptor {
+    void Start(detail::TypeErasedStream& stream) {
+      CHECK(streamforeach_->adaptor_.has_value());
+      CHECK(streamforeach_->inner_ == nullptr);
+      streamforeach_->inner_ = &stream;
+      streamforeach_->inner_->Next();
+    }
+
+    template <typename... Args>
+    void Body(Args&&... args) {
+      streamforeach_->k_.Body(std::forward<Args>(args)...);
+    }
+
+    void Ended() {
+      CHECK(streamforeach_->adaptor_.has_value());
+      streamforeach_->adaptor_.reset();
+      CHECK(streamforeach_->inner_ != nullptr);
+      streamforeach_->inner_ = nullptr;
+
+      if (streamforeach_->done_) {
+        streamforeach_->outer_->Done();
+      } else {
+        streamforeach_->outer_->Next();
+      }
+    }
+
+    void Stop() {
+      streamforeach_->Stop();
+    }
+
+    void Register(Interrupt&) {
+      // Already registered K once in 'StreamForEach::Body()'.
+    }
+
+    StreamForEach_* streamforeach_;
+  };
+
+  template <typename K_, typename F_, typename Arg_>
+  struct Continuation : public detail::TypeErasedStream {
+    // NOTE: explicit constructor because inheriting 'TypeErasedStream'.
+    Continuation(K_ k, F_ f)
+      : k_(std::move(k)),
+        f_(std::move(f)) {}
+
+    void Start(detail::TypeErasedStream& stream) {
+      outer_ = &stream;
+      k_.Start(*this);
+    }
+
+    template <typename... Args>
+    void Fail(Args&&... args) {
+      k_.Fail(std::forward<Args>(args)...);
+    }
+
+    void Stop() {
+      done_ = true;
+      k_.Stop();
+    }
+
+    void Register(Interrupt& interrupt) {
+      assert(interrupt_ == nullptr);
+      interrupt_ = &interrupt;
+      k_.Register(interrupt);
+    }
+
+    template <typename... Args>
+    void Body(Args&&... args) {
+      CHECK(!adaptor_.has_value());
+
+      adaptor_.emplace(
+          f_(std::forward<Args>(args)...)
+              .template k<void>(Adaptor<Continuation>{this}));
+
+      if (interrupt_ != nullptr) {
+        adaptor_->Register(*interrupt_);
+      }
+
+      adaptor_->Start();
+    }
+
+    void Ended() {
+      CHECK(!adaptor_.has_value());
+      k_.Ended();
+    }
+
+    void Next() override {
+      if (adaptor_.has_value()) {
+        CHECK_NOTNULL(inner_)->Next();
+      } else {
+        outer_->Next();
+      }
+    }
+
+    void Done() override {
+      done_ = true;
+      if (adaptor_.has_value()) {
+        CHECK_NOTNULL(inner_)->Done();
+      } else {
+        outer_->Done();
+      }
+    }
+
+    K_ k_;
+    F_ f_;
+
+    detail::TypeErasedStream* outer_ = nullptr;
+    detail::TypeErasedStream* inner_ = nullptr;
+
+    using E_ = typename std::invoke_result<F_, Arg_>::type;
+
+    using Adaptor_ = decltype(std::declval<E_>().template k<void>(
+        std::declval<Adaptor<Continuation>>()));
+
+    std::optional<Adaptor_> adaptor_;
+
+    Interrupt* interrupt_ = nullptr;
+
+    bool done_ = false;
+  };
+
+  template <typename F_>
+  struct Composable {
+    template <typename Arg>
+    using ValueFrom = typename std::conditional_t<
+        std::is_void_v<Arg>,
+        std::invoke_result<F_>,
+        std::invoke_result<F_, Arg>>::type::template ValueFrom<void>;
+
+    template <typename Arg, typename K>
+    auto k(K k) && {
+      return Continuation<K, F_, Arg>{std::move(k), std::move(f_)};
+    }
+
+    F_ f_;
+  };
+};
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace detail
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename F>
+auto StreamForEach(F f) {
+  return detail::_StreamForEach::Composable<F>{std::move(f)};
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace eventuals
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -18,6 +18,7 @@ eventuals_base_sources = [
     "take.cc",
     "range.cc",
     "let.cc",
+    "stream-for-each.cc",
 ]
 
 eventuals_events_sources = [

--- a/test/stream-for-each.cc
+++ b/test/stream-for-each.cc
@@ -1,0 +1,270 @@
+#include "stout/stream-for-each.h"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "stout/collect.h"
+#include "stout/event-loop.h"
+#include "stout/iterate.h"
+#include "stout/let.h"
+#include "stout/map.h"
+#include "stout/range.h"
+#include "stout/stream.h"
+#include "stout/terminal.h"
+#include "stout/then.h"
+#include "stout/timer.h"
+#include "test/event-loop-test.h"
+
+using stout::eventuals::Collect;
+using stout::eventuals::EventLoop;
+using stout::eventuals::Interrupt;
+using stout::eventuals::Iterate;
+using stout::eventuals::Let;
+using stout::eventuals::Map;
+using stout::eventuals::Range;
+using stout::eventuals::Stream;
+using stout::eventuals::StreamForEach;
+using stout::eventuals::Then;
+using stout::eventuals::Timer;
+using testing::ElementsAre;
+
+TEST(StreamForEach, TwoLevelLoop) {
+  auto s = []() {
+    return Range(2)
+        | StreamForEach([](int x) { return Range(2); })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1));
+}
+
+TEST(StreamForEach, StreamForEachMapped) {
+  auto s = []() {
+    return Range(2)
+        | StreamForEach([](int x) { return Range(2); })
+        | Map(Then([](int x) { return x + 1; }))
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(1, 2, 1, 2));
+}
+
+TEST(StreamForEach, StreamForEachIterate) {
+  auto s = []() {
+    return Range(2)
+        | StreamForEach([](int x) {
+             std::vector<int> v = {1, 2, 3};
+             return Iterate(std::move(v));
+           })
+        | Map(Then([](int x) { return x + 1; }))
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(2, 3, 4, 2, 3, 4));
+}
+
+TEST(StreamForEach, TwoIndexesSum) {
+  auto s = []() {
+    return Range(3)
+        | StreamForEach([](int x) {
+             return Stream<int>()
+                 .next([container = std::vector<int>({1, 2}),
+                        i = 0u,
+                        x](auto& k) mutable {
+                   if (i != container.size()) {
+                     k.Emit(container[i++] + x);
+                   } else {
+                     k.Ended();
+                   }
+                 })
+                 .done([](auto& k) {
+                   k.Ended();
+                 });
+           })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(1, 2, 2, 3, 3, 4));
+}
+
+TEST(StreamForEach, TwoIndexesSumMap) {
+  auto s = []() {
+    return Range(3)
+        | StreamForEach([](int x) {
+             return Range(1, 3)
+                 | Map(Then([x](int y) { return x + y; }));
+           })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(1, 2, 2, 3, 3, 4));
+}
+
+TEST(StreamForEach, Let) {
+  auto s = []() {
+    return Iterate({1, 2})
+        | StreamForEach(Let([](int& x) {
+             return Iterate({1, 2})
+                 | StreamForEach(Let([&x](int& y) {
+                      return Iterate({x, y});
+                    }));
+           }))
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(1, 1, 1, 2, 2, 1, 2, 2));
+}
+
+TEST(StreamForEach, StreamForEachIterateString) {
+  auto s = []() {
+    return Iterate(std::vector<std::string>({"abc", "abc"}))
+        | StreamForEach([](std::string x) {
+             std::vector<int> v = {1, 2, 3};
+             return Iterate(std::move(v));
+           })
+        | Map(Then([](int x) { return x + 1; }))
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(2, 3, 4, 2, 3, 4));
+}
+
+TEST(StreamForEach, ThreeLevelLoop) {
+  auto s = []() {
+    return Range(2)
+        | StreamForEach([](int x) { return Range(2); })
+        | StreamForEach([](int x) { return Range(2); })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
+}
+
+TEST(StreamForEach, ThreeLevelLoopInside) {
+  auto s = []() {
+    return Range(2)
+        | StreamForEach([](int x) {
+             return Range(2)
+                 | StreamForEach([](int y) {
+                      return Range(2);
+                    });
+           })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1));
+}
+
+TEST(StreamForEach, ThreeIndexesSumMap) {
+  auto s = []() {
+    return Range(3)
+        | StreamForEach([](int x) {
+             return Range(1, 3)
+                 | Map(Then([x](int y) { return x + y; }));
+           })
+        | StreamForEach([](int sum) {
+             return Range(1, 3)
+                 | Map(Then([sum](int z) { return sum + z; }));
+           })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(2, 3, 3, 4, 3, 4, 4, 5, 4, 5, 5, 6));
+}
+
+// Shows that you can stream complex templated objects.
+TEST(StreamForEach, VectorVector) {
+  auto s = []() {
+    return Iterate(std::vector<int>({2, 3, 14}))
+        | StreamForEach([](int x) {
+             std::vector<std::vector<int>> c;
+             c.push_back(std::vector<int>());
+             c.push_back(std::vector<int>());
+             return Iterate(std::move(c));
+           })
+        | StreamForEach([](std::vector<int> x) { return Range(2); })
+        | Collect<std::vector<int>>();
+  };
+
+  EXPECT_THAT(*s(), ElementsAre(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1));
+}
+
+class StreamForEachTest : public EventLoopTest {};
+
+TEST_F(StreamForEachTest, Interrupt) {
+  auto e = []() {
+    return Iterate(std::vector<int>(1000))
+        | Map(Then([](int x) { return Timer(std::chrono::milliseconds(100))
+                                   | Then([x]() { return x; }); }))
+        | StreamForEach([](int x) { return Iterate({1, 2}); })
+        | Collect<std::vector<int>>()
+              .stop([](auto& data, auto& k) {
+                k.Start(std::move(data));
+              });
+  };
+
+  auto [future, k] = Terminate(e());
+
+  Interrupt interrupt;
+
+  k.Register(interrupt);
+
+  k.Start();
+
+  interrupt.Trigger();
+
+  EventLoop::Default().Run();
+
+  auto result = future.get();
+
+  CHECK_EQ(result.size(), 0);
+}
+
+TEST(StreamForEach, InterruptReturn) {
+  std::atomic<bool> waiting = false;
+  std::atomic<bool> interrupted = false;
+
+  auto e = [&]() {
+    return Iterate(std::vector<int>(1000))
+        | StreamForEach([&](int x) {
+             return Stream<int>()
+                 .start([&](auto& k) {
+                   waiting.store(true);
+                 })
+                 .next([](auto& k) {
+                   k.Ended();
+                 })
+                 .interrupt([&](auto& k) {
+                   interrupted.store(true);
+                   k.Stop();
+                 });
+           })
+        | Collect<std::vector<int>>();
+  };
+
+  auto [future, k] = Terminate(e());
+
+  Interrupt interrupt;
+
+  k.Register(interrupt);
+
+  ASSERT_FALSE(waiting.load());
+  ASSERT_FALSE(interrupted.load());
+
+  k.Start();
+
+  ASSERT_TRUE(waiting.load());
+  ASSERT_FALSE(interrupted.load());
+
+  interrupt.Trigger();
+
+  EXPECT_THROW(future.get(), stout::eventuals::StoppedException);
+
+  ASSERT_TRUE(interrupted.load());
+}


### PR DESCRIPTION
`StreamForEach` is an instance that provides to create streams with inner loops

Let's imagine that a single common stream represents a one-level loop like

`Range(n)`  equals to `for (int i =0; i < n; ++i){...}`

When there is a composition of that Range with `StreamForEach([](int x) { return Range(k); })` it equals to 

```
for (int i = 0; i < n; ++i)
{
    for (int j = 0; k < 2; ++k){...}
}
```

In other words - it adds the inner loop inside the loop above each time you compose it with `StreamForEach`

The idea - pass a `Lamda` to the `StreamForEach` that produces a `Stream` instance (for now it instance that inherits from `TypeErasedStream` structure) and this `Stream` will be the inner loop for the stream above.

