### PR TITLE
Pin threads to specific cores

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
         "stout/lock.h",
         "stout/loop.h",
         "stout/map.h",
+        "stout/os.h",
         "stout/parallel.h",
         "stout/raise.h",
         "stout/range.h",
@@ -35,6 +36,7 @@ cc_library(
         "stout/sequence.h",
         "stout/static-thread-pool.h",
         "stout/stream.h",
+        "stout/stream-for-each.h",
         "stout/take.h",
         "stout/task.h",
         "stout/terminal.h",
@@ -42,7 +44,6 @@ cc_library(
         "stout/type-traits.h",
         "stout/undefined.h",
         "stout/until.h",
-        "stout/stream-for-each.h",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/stout/os.h
+++ b/stout/os.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <thread>
+
+#include "glog/logging.h" // NOTE: must be included before <windows.h>.
+
+#ifdef __MACH__
+#include <limits>
+#elif _WIN32
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif // __MACH__
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+
+////////////////////////////////////////////////////////////////////////
+
+#ifdef __MACH__
+inline size_t GetRunningCPU() {
+  // NOTE: Returning incorrect value here because
+  // we don't currently know a way to correctly recognize
+  // on which core the current thread is running.
+  return std::numeric_limits<size_t>::max();
+}
+
+inline void SetAffinity(std::thread& thread, const size_t cpu) {
+  // NOTE: We can't reliably set affinity for threads in MacOS.
+  return;
+}
+#elif _WIN32
+inline size_t GetRunningCPU() {
+  return GetCurrentProcessorNumber();
+}
+
+inline void SetAffinity(std::thread& thread, const size_t cpu) {
+  CHECK_NE(
+      SetThreadAffinityMask(
+          thread.native_handle(),
+          DWORD_PTR(1) << cpu),
+      0);
+}
+#else
+inline size_t GetRunningCPU() {
+  return sched_getcpu();
+}
+
+inline void SetAffinity(std::thread& thread, const size_t cpu) {
+  cpu_set_t cpuset = {};
+  CPU_ZERO(&cpuset);
+  CPU_SET(cpu, &cpuset);
+  CHECK_EQ(
+      pthread_setaffinity_np(
+          thread.native_handle(),
+          sizeof(cpu_set_t),
+          &cpuset),
+      0);
+}
+#endif // __MACH__
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////

--- a/stout/static-thread-pool.cc
+++ b/stout/static-thread-pool.cc
@@ -1,5 +1,7 @@
 #include "stout/static-thread-pool.h"
 
+#include "stout/os.h"
+
 ////////////////////////////////////////////////////////////////////////
 
 namespace stout {
@@ -20,6 +22,13 @@ StaticThreadPool::StaticThreadPool()
         [this, core]() {
           StaticThreadPool::member = true;
           StaticThreadPool::core = core;
+
+          SetAffinity(threads_[core], core);
+
+          STOUT_EVENTUALS_LOG(3) << "Thread " << core << " (id="
+                                 << std::this_thread::get_id()
+                                 << ") is running on core "
+                                 << GetRunningCPU();
 
           // NOTE: we store each 'semaphore' and 'head' in each thread
           // so as to hopefully get less false sharing when other


### PR DESCRIPTION
This PR makes so that each thread in static thread pool is mapped to a specific core which is determined by the position of a particular thread inside vector.